### PR TITLE
Add HF integration

### DIFF
--- a/CSD/model.py
+++ b/CSD/model.py
@@ -4,6 +4,8 @@ import clip
 import copy
 from torch.autograd import Function
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 from .utils import convert_weights_float
 
@@ -55,7 +57,7 @@ def init_weights(m): # TODO: do we need init for layernorm?
             nn.init.normal_(m.bias, std=1e-6)
 
 
-class CSD_CLIP(nn.Module):
+class CSD_CLIP(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/learn2phoenix/CSD", pipeline_tag="image-feature-extraction", license="mit"):
     """backbone + projection head"""
     def __init__(self, name='vit_large',content_proj_head='default'):
         super(CSD_CLIP, self).__init__()

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ conda activate style
 
 ## Download the pretrained weights for the CSD model
 
-Please download the CSD model (ViT-L) weights [here](https://drive.google.com/file/d/1FX0xs8p-C7Ob-h5Y4cUhTeOepHzXv_46/view?usp=sharing). 
+If you want to download the model directly, the CSD model (ViT-L) weights [here](https://drive.google.com/file/d/1FX0xs8p-C7Ob-h5Y4cUhTeOepHzXv_46/view?usp=sharing).
+If you are using huggingface, the CSD model (ViT-L) is [here](https://huggingface.co/tomg-group-umd/CSD-ViT-L).
 
 
 ## Download the pretrained weights for the baseline models


### PR DESCRIPTION
Hi @learn2phoenix,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the model using `from_pretrained` (and push it using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis, and perhaps most importantly, leverage `safetensors` for the weights in favor of pickle. 

Also, this greatly improves the discoverability of your model (as it's currently hosted on Google Drive which is hard to find).

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from CSD.model import CSD_CLIP
from huggingface_hub import hf_hub_download
import torch

# instantiate model
model = CSD_CLIP("resnet50", "default")

# equip model with weights
filepath = hf_hub_download(repo_id="tomg-group-umd/CSD-ViT-L", filename="checkpoint.pth", repo_type="model")
state_dict = torch.load(filepath, map_location="cpu)
model.load_state_dict(state_dict)

# push to hub
model.push_to_hub("your-hf-org-or-username/csd-clip")

# reload
model = CSD_CLIP.from_pretrained("your-hf-org-or-username/csd-clip")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. 

Would you be interested in this integration?

Kind regards,

Niels

## Note

Please don't merge this PR before pushing the model to the hub :)